### PR TITLE
feat: add Altinn Uptime SLA dashboard in altinn-uptime folder

### DIFF
--- a/dashboards/altinn-uptime/.lint
+++ b/dashboards/altinn-uptime/.lint
@@ -1,0 +1,26 @@
+exclusions:
+  target-instance-rule:
+    reason: >-
+      Fleet-wide SLA overview: panels intentionally match every instance by
+      domain regex (*.apps.altinn.no / *.apps.tt02.altinn.no) and break down
+      per customer. There is no single-$instance drill-down by design.
+    entries:
+      - dashboard: SLA - Altinn Uptime
+  target-job-rule:
+    reason: >-
+      Queries read the recording rule altinn:probe_success:max_by_instance,
+      which is aggregated across jobs; a $job matcher is not applicable.
+    entries:
+      - dashboard: SLA - Altinn Uptime
+  template-instance-rule:
+    reason: >-
+      Overview dashboard has no per-instance filter variable by design (see
+      target-instance-rule).
+    entries:
+      - dashboard: SLA - Altinn Uptime
+  template-job-rule:
+    reason: >-
+      Overview dashboard has no per-job filter variable by design (see
+      target-job-rule).
+    entries:
+      - dashboard: SLA - Altinn Uptime

--- a/dashboards/altinn-uptime/sla.json
+++ b/dashboards/altinn-uptime/sla.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "links": [],
@@ -36,7 +36,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "pS6ZuGV7z"
+        "uid": "${datasource}"
       },
       "description": "Prod SLA: availability across all hours. Green = meets 99.9% SLA.",
       "fieldConfig": {
@@ -172,7 +172,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "pS6ZuGV7z"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "label_replace(\n  avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]altinn[.]no$\"\n    }[$__range]\n  ) * 100,\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]altinn[.]no$\"\n)",
@@ -185,7 +185,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "pS6ZuGV7z"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "label_replace(\n  (1 - avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]altinn[.]no$\"\n    }[$__range]\n  )) * ($__range_ms / 60000),\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]altinn[.]no$\"\n)",
@@ -251,7 +251,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "pS6ZuGV7z"
+        "uid": "${datasource}"
       },
       "description": "Availability % over selected period for tt02 targets.\n\nNOTE: Business hours filtering (Mon–Fri 07:00–20:00 Oslo) cannot be applied accurately without a Prometheus recording rule. This shows overall uptime % — actual business-hours SLA will be equal or better than shown here since off-hours downtime is included in the denominator.",
       "fieldConfig": {
@@ -387,7 +387,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "pS6ZuGV7z"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "label_replace(\n  avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]tt02[.]altinn[.]no$\"\n    }[$__range]\n  ) * 100,\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]tt02[.]altinn[.]no$\"\n)",
@@ -400,7 +400,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "pS6ZuGV7z"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "label_replace(\n  (1 - avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]tt02[.]altinn[.]no$\"\n    }[$__range]\n  )) * ($__range_ms / 60000),\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]tt02[.]altinn[.]no$\"\n)",
@@ -460,7 +460,22 @@
     "sla"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-30d",

--- a/dashboards/altinn-uptime/sla.json
+++ b/dashboards/altinn-uptime/sla.json
@@ -1,0 +1,475 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Prod — SLA 99.9% (all hours, all days)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pS6ZuGV7z"
+      },
+      "description": "Prod SLA: availability across all hours. Green = meets 99.9% SLA.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "minWidth": 100
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 99.5
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Customer"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instance"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 260
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Downtime (min)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "SLA %"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pS6ZuGV7z"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(\n  avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]altinn[.]no$\"\n    }[$__range]\n  ) * 100,\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]altinn[.]no$\"\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pS6ZuGV7z"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(\n  (1 - avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]altinn[.]no$\"\n    }[$__range]\n  )) * ($__range_ms / 60000),\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]altinn[.]no$\"\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Prod — Per-customer SLA % (sorted worst first)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "cluster": true,
+              "container": true,
+              "endpoint": true,
+              "ip_family": true,
+              "job": true,
+              "microsoft.resourceid": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "target": true
+            },
+            "indexByName": {
+              "Customer": 0,
+              "Instance": 1,
+              "Value #A": 2,
+              "Value #B": 3
+            },
+            "renameByName": {
+              "Value #A": "SLA %",
+              "Value #B": "Downtime (min)",
+              "customer": "Customer",
+              "instance": "Instance"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 11,
+      "panels": [],
+      "title": "tt02 / Test — SLA 99.8% target (Mon–Fri 07:00–20:00 Oslo)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pS6ZuGV7z"
+      },
+      "description": "Availability % over selected period for tt02 targets.\n\nNOTE: Business hours filtering (Mon–Fri 07:00–20:00 Oslo) cannot be applied accurately without a Prometheus recording rule. This shows overall uptime % — actual business-hours SLA will be equal or better than shown here since off-hours downtime is included in the denominator.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "minWidth": 100
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 99.5
+              },
+              {
+                "color": "green",
+                "value": 99.8
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Customer"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 160
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instance"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 260
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SLA %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Downtime (min)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "SLA %"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pS6ZuGV7z"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(\n  avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]tt02[.]altinn[.]no$\"\n    }[$__range]\n  ) * 100,\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]tt02[.]altinn[.]no$\"\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pS6ZuGV7z"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(\n  (1 - avg_over_time(\n    altinn:probe_success:max_by_instance{\n      instance=~\"^[^.]+[.]apps[.]tt02[.]altinn[.]no$\"\n    }[$__range]\n  )) * ($__range_ms / 60000),\n  \"customer\",\n  \"$1\",\n  \"instance\",\n  \"^([^.]+)[.]apps[.]tt02[.]altinn[.]no$\"\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "tt02 — Per-customer SLA % business hours (sorted worst first)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "cluster": true,
+              "container": true,
+              "endpoint": true,
+              "ip_family": true,
+              "job": true,
+              "microsoft.resourceid": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "target": true
+            },
+            "indexByName": {
+              "Customer": 0,
+              "Instance": 1,
+              "Value #A": 2,
+              "Value #B": 3
+            },
+            "renameByName": {
+              "Value #A": "SLA %",
+              "Value #B": "Downtime (min)",
+              "customer": "Customer",
+              "instance": "Instance"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 42,
+  "tags": [
+    "prometheus",
+    "blackbox-exporter",
+    "sla"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "Europe/Oslo",
+  "title": "SLA - Altinn Uptime",
+  "uid": "altinn-sla-002",
+  "version": 1,
+  "weekStart": ""
+}

--- a/dashboards/dashboards.yaml
+++ b/dashboards/dashboards.yaml
@@ -57,6 +57,20 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
+  name: external-grafana-altinn-uptime-sla
+  namespace: grafana
+spec:
+  folderRef: external-grafana-altinn-uptime
+  instanceSelector:
+    matchLabels:
+      dashboards: "external-grafana"
+  configMapRef:
+    name: dashboard-altinn-uptime-sla
+    key: sla.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
   name: external-grafana-fluxcd-flux-cluster-stats
   namespace: grafana
 spec:

--- a/dashboards/folders.yaml
+++ b/dashboards/folders.yaml
@@ -20,6 +20,25 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
+  name: external-grafana-altinn-uptime
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "external-grafana"
+  title: Altinn Uptime
+  permissions: |
+    {
+      "items": [
+        { "role": "Admin",  "permission": 4 },
+        { "role": "Editor", "permission": 1 },
+        { "role": "Viewer", "permission": 1 }
+      ]
+    }
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
   name: external-grafana-fluxcd
   namespace: grafana
 spec:

--- a/dashboards/kustomization.yaml
+++ b/dashboards/kustomization.yaml
@@ -19,6 +19,9 @@ configMapGenerator:
   - name: dashboard-altinn-traefik-official
     files:
       - altinn/traefik-official.json
+  - name: dashboard-altinn-uptime-sla
+    files:
+      - altinn-uptime/sla.json
   - name: dashboard-fluxcd-flux-cluster-stats
     files:
       - fluxcd/flux-cluster-stats.json


### PR DESCRIPTION
Adds a new platform-managed Grafana dashboard **SLA - Altinn Uptime** in a dedicated **Altinn Uptime** folder (`external-grafana-altinn-uptime`), wired as a `GrafanaDashboard` + `ConfigMap` per the repo's dashboard convention (root `dashboards/`, not a product overlay). The dashboard uses a templated Prometheus datasource (`${datasource}`, defaulting to the Grafana default datasource), is set `editable: false`, and ships a scoped `.lint` so it passes `dashboard-linter lint --strict` — the instance/job rules are excluded with documented reasons, since this is a fleet-wide all-customers SLA overview (matches every instance by domain regex, reads a pre-aggregated recording rule), not a per-instance drill-down. Validated locally: dashboard-wiring gate, `kustomize build .`, `kubeconform -strict`, `yamllint`, and `dashboard-linter --strict` — all green.

Note: not verified against live Grafana — panels need a default Prometheus datasource and the `altinn:probe_success:max_by_instance` recording rule present to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
