### PR TITLE
fix: pin SLA dashboard datasource variable to the obs AMWs

### DIFF
--- a/dashboards/altinn-uptime/sla.json
+++ b/dashboards/altinn-uptime/sla.json
@@ -472,7 +472,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "/admin-.*-obs-amw/",
         "type": "datasource"
       }
     ]


### PR DESCRIPTION
## Why

The **SLA - Altinn Uptime** dashboard showed 0/no data in `dis-grafana-prod`. Root cause (verified by querying the AMW Prometheus endpoints directly):

- The dashboard's datasource variable saves `default`, but the Grafana default datasource is Azure Monitor (not Prometheus), so Grafana silently falls back to the **first** Prometheus datasource — one of the `dis-core-*-products-amw` workspaces, which contain **no** `probe_success` data.
- The probe data + `altinn:*` recording rules live in `admin-{test,prod}-obs-amw`. The exact dashboard query returns per-customer results there (e.g. dibk: 5.0 min downtime over 7d).

## What

Set the datasource variable's `regex` to `/admin-.*-obs-amw/` so only the obs AMWs are selectable and the fallback lands on a datasource that has the data. In `dis-grafana-prod` that datasource is created by dis-way/adminservices#258 (AMW integration + Monitoring Data Reader + recording rules in prod), which should merge/apply first.

## Follow-up (not in this PR)

The tt02 panel's title says business hours (Mon–Fri 07:00–20:00 Oslo) but queries the plain `altinn:probe_success:max_by_instance` rule; dedicated `altinn:probe_success_tt02_business_hours*` rules exist and are probably what it should use.

## Validation

- `python scripts/validate-dashboards.py` — OK (10 dashboards wired)
- `kustomize build . | kubeconform -strict …` — 30 valid, 0 invalid, 3 skipped (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)