### PR TITLE
feat: add health-check endpoints table to Altinn Uptime SLA dashboard

### DIFF
--- a/dashboards/altinn-uptime/sla.json
+++ b/dashboards/altinn-uptime/sla.json
@@ -449,6 +449,247 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Health Checks — /health endpoints (HTTP 200 + body \"status\": \"Healthy\")",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Deep health-check endpoints probed by the blackbox http_health_check_ipv4/ipv6 modules: a probe passes only on HTTP 200 over the pinned IP family, valid TLS, and a JSON body starting with {\"status\":\"Healthy\"}. Availability % and Downtime are over the selected range; Current is the latest probe (UP/DOWN). These targets come from health_check_ipv4/ipv6 in the altinn-uptime extra-targets and are queried from raw probe_success, not the per-customer SLA recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "minWidth": 100
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 99.5
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 420
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Availability %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Downtime (min)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Current"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.width",
+                "value": 110
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "DOWN"
+                      },
+                      "1": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "UP"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Availability %"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (instance, target) (avg_over_time(probe_success{job=~\"blackbox-http-ipv[46]-health-check\"}[$__range])) * 100",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(1 - max by (instance, target) (avg_over_time(probe_success{job=~\"blackbox-http-ipv[46]-health-check\"}[$__range]))) * ($__range_ms / 60000)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (instance, target) (probe_success{job=~\"blackbox-http-ipv[46]-health-check\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "title": "Health check endpoints — availability & current status",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "target": true
+            },
+            "indexByName": {
+              "Endpoint": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3
+            },
+            "renameByName": {
+              "Value #A": "Availability %",
+              "Value #B": "Downtime (min)",
+              "Value #C": "Current",
+              "instance": "Endpoint"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "preload": false,


### PR DESCRIPTION
## What

Adds a **Health Checks** row + table to the "SLA - Altinn Uptime" dashboard (`dashboards/altinn-uptime/sla.json`) showing **availability %**, **downtime (min)**, and **current UP/DOWN status** for the `/health` endpoints probed by the blackbox `http_health_check_ipv4/ipv6` modules.

## Why

The health-check targets (`health_check_ipv4/ipv6` in the altinn-uptime `extra-targets`) were absent from the dashboard for two reasons, both verified against `admin-test-obs-amw`:

1. The existing tables read the recording rule `altinn:probe_success:max_by_instance`, which **does not include** the health-check instances.
2. They also filter `instance=~"*.apps.altinn.no"` / `"*.apps.tt02.altinn.no"`, which the health hostnames (`info.at22.altinn.cloud`, `discore-at23-…azure-api.net`) don't match.

The new table queries **raw** `probe_success{job=~"blackbox-http-ipv[46]-health-check"}` with `max by (instance, target)`, so it's independent of the recording rule. The `ipv[46]` regex future-proofs it for when `health_check_ipv6` targets are added.

## Validation

- All three panel queries validated live against `admin-test-obs-amw` (both endpoints 100% / UP).
- `scripts/validate-dashboards.py` passes (10/10 JSON ↔ ConfigMap ↔ CR).
- `kustomize build dashboards` renders cleanly; the new panel is present in the generated ConfigMap.

## Notes

- Appears in Grafana after merge → OCI artifact publish → Flux reconcile.
- Optional follow-up: add the health-check instances to the `altinn:probe_success:max_by_instance` recording rule (lives in Azure Managed Prometheus rule groups, outside this repo) for consistency with the SLA tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
