### PR TITLE
feat(infoportal): add health-check availability alert

### DIFF
--- a/products/infoportal/alerting/contact-points.yaml
+++ b/products/infoportal/alerting/contact-points.yaml
@@ -27,3 +27,31 @@ spec:
             secretKeyRef:
               name: grafana-slack-webhooks
               key: infoportal
+# Availability alert (rules-availability.yaml) posts to the SAME infoportal Slack webhook, but needs
+# its own contact point: the template above is exception-shaped and would render wrong for a probe alert.
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: infoportal-slack-availability
+  namespace: grafana
+spec:
+  name: "Infoportal Slack Availability"
+  instanceSelector:
+    matchLabels:
+      dashboards: external-grafana
+  resyncPeriod: 10m0s
+  receivers:
+    - type: slack
+      disableResolveMessage: false
+      settings:
+        title: 'Infoportal health check {{ if eq .Status "firing" }}:red_circle: DOWN{{ else }}:large_green_circle: recovered{{ end }} — {{ .CommonLabels.Env }}'
+        text: |
+          {{ range .Alerts }}{{ .Labels.instance }} — health check {{ .Status }}
+          {{ end }}{{ with (index .Alerts 0).PanelURL }}<{{ . }}|Open health-check panel>{{ end }}
+      valuesFrom:
+        - targetPath: url
+          valueFrom:
+            secretKeyRef:
+              name: grafana-slack-webhooks
+              key: infoportal

--- a/products/infoportal/alerting/kustomization.yaml
+++ b/products/infoportal/alerting/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - folder.yaml
   - contact-points.yaml
   - rules-exceptions.yaml
+  - rules-availability.yaml

--- a/products/infoportal/alerting/rules-availability.yaml
+++ b/products/infoportal/alerting/rules-availability.yaml
@@ -1,0 +1,81 @@
+# Hand-authored alert rule (not a Grafana UI export). Unlike rules-exceptions.yaml (Azure Log
+# Analytics / App Insights), this queries blackbox-exporter `probe_success` over the Prometheus
+# datasource `admin-prod-obs-amw` on dis-grafana-prod — the deep /health probe of info.altinn.no.
+# Keep the `uid` stable on edits; regenerating it duplicates the rule in Grafana.
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: infoportal-availability
+  namespace: grafana
+spec:
+  name: Availability
+  folderRef: external-grafana-infoportal
+  instanceSelector:
+    matchLabels:
+      dashboards: external-grafana
+  interval: 1m
+  rules:
+  - uid: infoportal-availability-prod
+    title: Availability Prod
+    condition: C
+    for: 5m
+    noDataState: NoData
+    execErrState: OK
+    labels:
+      AlertType: Availability
+      Env: Prod
+      Product: Infoportal
+      Severity: Critical
+    annotations:
+      summary: Infoportal health check failing in prod (info.altinn.no/health)
+      description: 'probe_success=0 for {{ $labels.instance }} — /health did not return HTTP 200 + status:Healthy'
+      __dashboardUid__: altinn-sla-002
+      __panelId__: "3"
+    notificationSettings:
+      receiver: Infoportal Slack Availability
+    data:
+    - refId: A
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: admin-prod-obs-amw
+      model:
+        datasource:
+          type: prometheus
+          uid: admin-prod-obs-amw
+        editorMode: code
+        expr: 'max by (instance) (probe_success{job=~"blackbox-http-ipv[46]-health-check", instance="info.altinn.no"})'
+        instant: true
+        range: false
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: A
+    - refId: C
+      relativeTimeRange:
+        from: 600
+        to: 0
+      datasourceUid: __expr__
+      model:
+        conditions:
+        - evaluator:
+            params:
+            - 1
+            type: lt
+          operator:
+            type: and
+          query:
+            params:
+            - C
+          reducer:
+            params: []
+            type: last
+          type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold


### PR DESCRIPTION
## What
A Grafana availability alert for Infoportal's deep health-check endpoint — a **separate** rule from the existing exceptions alert.

- **`rules-availability.yaml`** (new) — `GrafanaAlertRuleGroup infoportal-availability`, rule `Availability Prod` (uid `infoportal-availability-prod`). Prometheus query on the `admin-prod-obs-amw` datasource: `max by (instance)(probe_success{job=~"blackbox-http-ipv[46]-health-check", instance="info.altinn.no"})`, threshold `lt 1` (probe DOWN), `for: 5m`, `interval: 1m`, `Severity: Critical`, `noDataState: NoData`. First Prometheus-datasource alert in this repo (others use Azure Log Analytics).
- **`contact-points.yaml`** — new `Infoportal Slack Availability` contact point on the **same** `infoportal` webhook (the existing contact point's template is exception-shaped and would render wrong for a probe alert). Posts resolve messages + a link to the SLA dashboard health-check panel.
- **`kustomization.yaml`** — register the rules file.

## Depends on
dis-way/gitops-manifests#1349 (adds the `info.altinn.no/health` probe target). Until that syncs and the probe warms up, this rule sits in NoData (non-paging by design).

## Validated
`kustomize build` overlay (5) + root (35) OK; `kubeconform -strict` clean (32 valid, 3 expected skips: ExternalSecret/Vault/ApplicationIdentity).

## Note
kubeconform validates schema, not Grafana query evaluation — confirm the rule shows **Normal** (not Error) in Grafana once deployed. If it errors, switch refId A to `instant: false, range: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)