### PR TITLE
feat(infoportal): fan out availability alert to critical Slack channel

### DIFF
--- a/platform/secrets/external-secret.yaml
+++ b/platform/secrets/external-secret.yaml
@@ -18,3 +18,6 @@ spec:
     - secretKey: infoportal
       remoteRef:
         key: slack-webhook-infoportal-prod
+    - secretKey: infoportal-critical
+      remoteRef:
+        key: slack-webhook-infoportal-altinn-alerts-prod-critical

--- a/products/infoportal/alerting/contact-points.yaml
+++ b/products/infoportal/alerting/contact-points.yaml
@@ -55,3 +55,16 @@ spec:
             secretKeyRef:
               name: grafana-slack-webhooks
               key: infoportal
+    - type: slack
+      disableResolveMessage: false
+      settings:
+        title: 'Infoportal health check {{ if eq .Status "firing" }}:red_circle: DOWN{{ else }}:large_green_circle: recovered{{ end }} — {{ .CommonLabels.Env }}'
+        text: |
+          {{ range .Alerts }}{{ .Labels.instance }} — health check {{ .Status }}
+          {{ end }}{{ with (index .Alerts 0).PanelURL }}<{{ . }}|Open health-check panel>{{ end }}
+      valuesFrom:
+        - targetPath: url
+          valueFrom:
+            secretKeyRef:
+              name: grafana-slack-webhooks
+              key: infoportal-critical


### PR DESCRIPTION
## What

The infoportal health-check **availability** alert now posts to **both** Slack channels:
- the existing `infoportal-prod` channel (unchanged), and
- the new `altinn-alerts-prod-critical` channel.

## How

A Grafana contact point is the fan-out unit — a rule routes to it once and it fires all its integrations. So this adds a **second Slack integration** to the existing `Infoportal Slack Availability` contact point, using the same health-check template. **No rule change** (`rules-availability.yaml` still routes to `Infoportal Slack Availability`); the exceptions alert is untouched.

- `contact-points.yaml` — second `- type: slack` receiver → webhook key `infoportal-critical`.
- `external-secret.yaml` — new mapping `infoportal-critical` → vault `slack-webhook-infoportal-altinn-alerts-prod-critical`.

## ⚠️ Prerequisite before deploy

The secret **`slack-webhook-infoportal-altinn-alerts-prod-critical` must exist in the `grafana-alerting` Azure Key Vault**. The `ExternalSecret` syncs all keys into one k8s Secret — a missing vault key puts it in `SecretSyncError` and can block the whole Secret from updating.

## Deferred (Opsgenie, on hold)

When Opsgenie is added: append a third `- type: opsgenie` receiver to this same contact point + wire its API key, and rename the contact point `Infoportal Slack Availability` → `Infoportal Availability` (dropping "Slack", which only becomes inaccurate once a non-Slack destination joins).

## Validation (matches CI)

- `kustomize build` (overlay + root) — ✅
- `kubeconform -strict` — ✅ overlay 5/5 valid; root 32 valid, 3 skipped (ExternalSecret/Vault/ApplicationIdentity, expected)
- `yamllint -d relaxed` — ✅ no errors (only pre-existing long-line warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)