### PR TITLE
fix(infoportal): stop availability alert re-notifying every 4h

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,14 @@ have no vendored schema, which is expected (`-ignore-missing-schemas`).
 - **`severityLevel` is numeric.** Use `severityLevel >= 3`, not `== "3"` — a string compare can
   silently match nothing.
 - **`for: 0s` is mandatory.** The CRD rejects a rule without it; Grafana UI exports omit it.
+- **A firing alert re-notifies every 4h by default.** Nothing here defines a
+  `GrafanaNotificationPolicy`, so every rule inherits the central Grafana root policy
+  (`group_wait 30s`, `group_interval 5m`, **`repeat_interval 4h`**). A long incident re-posts the
+  *same* firing message every 4h, which reads like repeated independent failures. For state-style
+  alerts (availability/probe) where one firing + one resolve is the whole story, set
+  `notificationSettings.repeat_interval` explicitly — the CRD field is **snake_case**
+  (`repeat_interval`, not `repeatInterval`; `additionalProperties: false` rejects the camelCase
+  spelling). Grafana caps it at **120h** and coerces it to a multiple of `group_interval`.
 - **Never regenerate a rule `uid`.** Reuse it on every edit.
 - **Azure resource IDs are case-insensitive but use canonical casing** (`resourceGroups`,
   `Microsoft.Insights`) for consistency with existing rules — Azure Portal exports often

--- a/products/infoportal/alerting/rules-availability.yaml
+++ b/products/infoportal/alerting/rules-availability.yaml
@@ -34,6 +34,12 @@ spec:
       __panelId__: "3"
     notificationSettings:
       receiver: Infoportal Slack Availability
+      # Without this, the rule inherits the root policy's 4h repeat_interval and re-posts the same
+      # "DOWN" message every 4h for as long as the probe stays red — the real ~9h45m outage on
+      # 2026-08-04 read as three separate failures in Slack. 24h keeps one daily reminder that a
+      # Critical availability alert is still open, without the 4h nagging. Must be a multiple of
+      # the root group_interval (5m); 24h = 288 x 5m. Grafana's max is 120h.
+      repeat_interval: 24h
     data:
     - refId: A
       relativeTimeRange:


### PR DESCRIPTION
## Problem

`info.altinn.no` was genuinely down for ~9h45m on 2026-08-04. Slack showed it as **three** identical `🔴 DOWN — Prod` messages at 01:30, 05:30 and 09:30, then a single `🟢 recovered` at 11:10.

Those weren't three failures — they were one incident announced three times:

- 01:30 → 05:30 → 09:30 is **exactly 4h, twice**. Real outages don't land on that grid.
- The 11:10 recovery is *not* on the grid (1h40m after 09:30) — that's the genuine state change.
- The contact point has `disableResolveMessage: false`, so an actual resolve-and-refire would have posted a green message before each red one. There was only one.

**Root cause:** the rule sets no `repeat_interval`, and nothing in this repo defines a `GrafanaNotificationPolicy`, so it inherits the central Grafana root policy default — `repeat_interval: 4h`, which Grafana documents as "a reminder that alerts are still firing."

## Fix

Set `notificationSettings.repeat_interval: 24h` on `infoportal-availability-prod`.

24h rather than suppressing repeats entirely: this is a `Severity: Critical` availability alert, so an ongoing outage should still nag once a day — just not six times. Grafana's max is 120h if we ever want to go quieter.

Two details worth knowing, both now recorded in CLAUDE.md's Gotchas:
- The CRD field is **snake_case** `repeat_interval`. `notificationSettings` is `additionalProperties: false`, so `repeatInterval` fails `kubeconform -strict`.
- It must be a multiple of the root `group_interval` (5m). 24h = 288 × 5m. ✅

The rule `uid` is unchanged, per the repo's never-regenerate-a-uid rule.

## Validation

```
kustomize build products/infoportal/alerting  →  5 valid, 0 invalid
kustomize build .                             →  32 valid, 0 invalid, 3 expected skips
yamllint -d relaxed                           →  0 errors
```

Rendered output confirmed to contain `repeat_interval: 24h` under the correct receiver.

## Note for reviewers

This only changes notification *cadence*, not detection — `for: 5m`, the threshold, and the query are untouched. The outage itself was real and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)